### PR TITLE
PR: Mock HELP3O on rtd to fix technical documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,16 +6,31 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/stable/config
 
+from unittest.mock import MagicMock
+import os.path as osp
+import sys
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-import os.path as osp
-import sys
+
 dirname = osp.dirname(osp.dirname(__file__))
 sys.path.insert(0, osp.abspath(dirname))
+
+
+# We need to mock the HELP3O module because it cannot be compiled on RTD.
+# See PR #.
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return MagicMock()
+
+
+MOCK_MODULES = ['HELP3O']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
         return MagicMock()
 
 
-MOCK_MODULES = ['HELP3O']
+MOCK_MODULES = ['pyhelp.HELP3O']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ sys.path.insert(0, osp.abspath(dirname))
 
 
 # We need to mock the HELP3O module because it cannot be compiled on RTD.
-# See PR #.
+# See PR #18.
 class Mock(MagicMock):
     @classmethod
     def __getattr__(cls, name):


### PR DESCRIPTION
The technical documentation on RTD is currently not building because of an `import` error with the module `HELP3O`. We do not need this module to build the documentation, so we can simply mock it here.

I followed the instruction provided here:
https://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules