### PR TITLE
PR: Use m2w64-toolchain to build HELP3O on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ install:
   - conda config --set auto_update_conda no
   - conda config --add channels conda-forge
   - conda config --set channel_priority true
-  - conda install numpy scipy pandas xlrd netcdf4 h5py pytables matplotlib geopandas pytest pytest-mock pytest-cov codecov sphinx m2w64-toolchain m2w64-toolchain_win-64
+  - conda install numpy scipy pandas xlrd netcdf4 h5py pytables matplotlib geopandas pytest pytest-mock pytest-cov codecov sphinx m2w64-toolchain
   
   # Add mingw-w64 to SYS PATH.
   - set "PATH=%PYTHON%\Library\mingw-w64\bin;%PATH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,9 @@ install:
   - conda config --set channel_priority true
   - conda install numpy scipy pandas xlrd netcdf4 h5py pytables matplotlib geopandas pytest pytest-mock pytest-cov codecov sphinx m2w64-toolchain m2w64-toolchain_win-64
   
+  # Add mingw-w64 to SYS PATH.
+  - set "PATH=%PYTHON%\Library\mingw-w64\bin;%PATH%"
+
 build: false
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ environment:
   # https://www.appveyor.com/docs/installed-software#python
 
   global:
-    MINGW_64: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin"
     APPVEYOR_RDP_PASSWORD: "dcca4c4863E30d56c2e0dda6327370b3#"
 
   matrix:
@@ -36,7 +35,6 @@ install:
   
   # Setup SYS PATH.
   - set "PATH=%PYTHON%;%PYTHON%\Scripts;%PYTHON%\Library\bin;%PATH%"
-  - set "PATH=%MINGW_64%;%PATH%"
   
   # Setup Conda.
   - conda config --set always_yes yes
@@ -44,7 +42,7 @@ install:
   - conda config --set auto_update_conda no
   - conda config --add channels conda-forge
   - conda config --set channel_priority true
-  - conda install numpy scipy pandas xlrd netcdf4 h5py pytables matplotlib geopandas pytest pytest-mock pytest-cov codecov sphinx
+  - conda install numpy scipy pandas xlrd netcdf4 h5py pytables matplotlib geopandas pytest pytest-mock pytest-cov codecov sphinx m2w64-toolchain m2w64-toolchain_win-64
   
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 environment:
-  # https://www.appveyor.com/docs/installed-software#python
-
   global:
     APPVEYOR_RDP_PASSWORD: "dcca4c4863E30d56c2e0dda6327370b3#"
 
@@ -47,10 +45,12 @@ install:
   # Add mingw-w64 to SYS PATH.
   - set "PATH=%PYTHON%\Library\mingw-w64\bin;%PATH%"
 
+  # Build the HELP3O extension.
+  - python setup.py build_ext
+
 build: false
 
 test_script:
-  - python setup.py build_ext
   - python runtests.py
 
 on_success:


### PR DESCRIPTION
Fixes #26

I think that using the m2w64-toolchain directly from Anaconda will make it easier to build the HELP3O extension on multiple platform instead of using the OS installed mingw-w64 compilers.

At the very least, it will allow to simplifies the `install and contribute` section of the documentation.